### PR TITLE
Check url before extracting user and repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ##Pending - x.x.x
 
 * toolbag removed.
+* Checking that github url exists before trying to extract user and repo
+* Stars, forks and watches are now assigned 0 instead of an empty string if repo.* is empty
 
 ## 10 April - 6.2.0
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -41,27 +41,32 @@ function cmdGet (msg, done) {
 
       var data = null
 
-      try {data = JSON.parse(body)}
-      catch (e) {return done(e)}
+      try { data = JSON.parse(body) }
+      catch (e) { return done(e) }
 
       var distTags = data['dist-tags'] || {}
       var latest = ((data.versions || {})[distTags.latest]) || {}
       var repository = latest.repository || {}
       var url = repository.url || ''
 
-      var matches = /[\/:]([^\/:]+?)[\/:]([^\/]+?)(\.git)*$/.exec(url)
-      var params = {
-        name: msg.name,
-        url: url,
-        user: matches[1] || null,
-        repo: matches[2] || null
-      }
+      if(url.length > 0) {
+        var matches = /[\/:]([^\/:]+?)[\/:]([^\/]+?)(\.git)*$/.exec(url)
+        var params = {
+          name: msg.name,
+          url: url,
+          user: matches[1] || null,
+          repo: matches[2] || null
+        }
 
-      if (!params.user || !params.repo) {
+        if (!params.user || !params.repo) {
+          return done(new Error('not found on npm'))
+        }
+
+        queryGithub(params, done)
+      }
+      else{
         return done(new Error('not found on npm'))
       }
-
-      queryGithub(params, done)
     })
   })
 }
@@ -104,9 +109,9 @@ function queryGithub (msg, done) {
         name: msg.repo || '',
         user: msg.user || '',
         repo: msg.repo || '',
-        stars: repo.stargazers_count || '',
-        watches: repo.subscribers_count || '',
-        forks: repo.forks_count || '',
+        stars: repo.stargazers_count || 0,
+        watches: repo.subscribers_count || 0,
+        forks: repo.forks_count || 0,
         last: repo.pushed_at || '',
         urlRepo: 'https://github.com/' + msg.user + '/' + msg.repo,
         urlClone: 'git+https://github.com/' + msg.user + '/' + msg.repo + '.git',


### PR DESCRIPTION
Check github url exists before extracting user and repo. Stars, forks and watches are now assigned 0 instead of an empty string when repo has none.